### PR TITLE
Update babylon-parser.js (Add  'nullishCoalescingOperator')

### DIFF
--- a/src/parsers/babylon-parser.js
+++ b/src/parsers/babylon-parser.js
@@ -15,7 +15,8 @@ module.exports = (type, plugins) => input =>
         'functionSent',
         'dynamicImport',
         'optionalCatchBinding',
-        'optionalChaining'
+        'optionalChaining',
+        'nullishCoalescingOperator'
       ]
     )
   })


### PR DESCRIPTION
Nullish coalescing, like optional chaining is at stage 1.

We've added our own parserPlugins to processor options, but now we have to maintain it on our own.
This problem is easily solved by adding it to the default plugin list. 🌮 